### PR TITLE
Update max empty line rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = {
     "max-len": [1, 180, 4],
     "no-else-return": 0,
     "no-use-before-define": 0,
+    "no-multiple-empty-lines": [2, { "max": 1, "maxBOF": 0, "maxEOF": 1 }],
     "no-underscore-dangle": 0,
     "react/jsx-closing-bracket-location": [2, {selfClosing: "after-props"}],
     "react/jsx-no-bind": [0],


### PR DESCRIPTION
- Allow 0 empty lines at beginning of file
- Allow 1 empty line at end of file
- Allow max of 1 empty line elsewhere

Can be automatically fixed with `eslint --fix`
